### PR TITLE
Fix error counting

### DIFF
--- a/autoload/lightline/lsp.vim
+++ b/autoload/lightline/lsp.vim
@@ -97,7 +97,12 @@ endfunction
 " Helper functions
 
 function! s:count(level) abort
-  return luaeval('vim.lsp.diagnostic.get_count(' . bufnr() . ', [[' . a:level . ']])') || 0
+  let result = luaeval('vim.lsp.diagnostic.get_count(' . bufnr() . ', [[' . a:level . ']])')
+  if result
+    return l:result
+  else
+    return 0
+  end
 endfunction
 
 function! s:countSum() abort

--- a/autoload/lightline/lsp.vim
+++ b/autoload/lightline/lsp.vim
@@ -98,7 +98,7 @@ endfunction
 
 function! s:count(level) abort
   let result = luaeval('vim.lsp.diagnostic.get_count(' . bufnr() . ', [[' . a:level . ']])')
-  if result
+  if l:result
     return l:result
   else
     return 0


### PR DESCRIPTION
The `||` operator coerces the result into boolean (0 or 1), which loses the actual number of errors/warnings/etc