### PR TITLE
fix(diagnostic): update deprecated diagnostic

### DIFF
--- a/autoload/lightline/lsp.vim
+++ b/autoload/lightline/lsp.vim
@@ -97,7 +97,7 @@ endfunction
 " Helper functions
 
 function! s:count(level) abort
-  return luaeval('vim.lsp.diagnostic.get_count(' . bufnr() . ', [[' . a:level . ']])') || 0
+  return luaeval('vim.diagnostic.get(' . bufnr() . ', [[' . a:level . ']])') || 0
 endfunction
 
 function! s:countSum() abort


### PR DESCRIPTION
Replace deprecated 'vim.lsp.diagnostic.get_count()' with updated
'vim.diagnostic.get()' in 'autoload/lightline/lsp.vim'.

The deprecated function generates a warning message every time a buffer
is loaded.