### PR TITLE
replace deprecated "vim.lsp.buf_get_clients()"

### DIFF
--- a/autoload/lightline/lsp.vim
+++ b/autoload/lightline/lsp.vim
@@ -107,7 +107,7 @@ function! s:countSum() abort
 endfunction
 
 function! s:isHidden()
-  return !luaeval('not vim.tbl_isempty(vim.lsp.buf_get_clients('.bufnr().'))') || exists('*lightline#sensible#isHidden') && lightline#sensible#isHidden()
+  return !luaeval('not vim.tbl_isempty(vim.lsp.get_clients({bufnr = '.bufnr().'}))') || exists('*lightline#sensible#isHidden') && lightline#sensible#isHidden()
 endfunction
 
 function! s:setLightline(scope, name, value) abort

--- a/lua/jg/lightline/lsp.lua
+++ b/lua/jg/lightline/lsp.lua
@@ -102,7 +102,7 @@ function M.client_names()
   local clients = {}
   local icon = ' '
 
-  for _, client in pairs(vim.lsp.buf_get_clients()) do
+  for _, client in pairs(vim.lsp.get_clients({bufnr = vim.fn.bufnr()})) do
     clients[#clients+1] = icon .. client.name
   end
 


### PR DESCRIPTION
SSIA

see `:h vim.lsp.buf_get_clients()`

> vim.lsp.buf_get_clients() Use vim.lsp.get_clients() with {buffer=bufnr} instead.